### PR TITLE
商品削除機能の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,13 +3,15 @@ class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   private
+
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys:[:nickname, :last_name, :first_name, :last_reading, :first_reading, :birthday])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :last_name, :first_name, :last_reading, :first_reading, :birthday])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :correct_user, only: [:edit, :update]
+  before_action :correct_user, only: [:edit, :update, :destroy]
   before_action :set_params, only: [:show, :edit, :update, :destroy]
   
   def index

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,9 +2,9 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :correct_user, only: [:edit, :update, :destroy]
   before_action :set_params, only: [:show, :edit, :update, :destroy]
-  
+
   def index
-    @items = Item.all.order("created_at DESC") 
+    @items = Item.all.order('created_at DESC')
   end
 
   def new
@@ -44,8 +44,10 @@ class ItemsController < ApplicationController
   end
 
   private
+
   def item_params
-    params.require(:item).permit(:image,:name,:info,:category_id,:item_status_id,:shipping_id,:area_id,:schedule_id,:price).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :name, :info, :category_id, :item_status_id, :shipping_id, :area_id, :schedule_id,
+                                 :price).merge(user_id: current_user.id)
   end
 
   def correct_user

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,6 +37,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def destroy
+    item = Item.find(params[:id])
+    item.destroy
+  end
+
   private
   def item_params
     params.require(:item).permit(:image,:name,:info,:category_id,:item_status_id,:shipping_id,:area_id,:schedule_id,:price).merge(user_id: current_user.id)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :correct_user, only: [:edit, :update]
-  before_action :set_params, only: [:show, :edit, :update]
+  before_action :set_params, only: [:show, :edit, :update, :destroy]
   
   def index
     @items = Item.all.order("created_at DESC") 
@@ -38,8 +38,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    item = Item.find(params[:id])
-    item.destroy
+    # before_actionでset済み
+    @item.destroy
     redirect_to root_path
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,6 +40,7 @@ class ItemsController < ApplicationController
   def destroy
     item = Item.find(params[:id])
     item.destroy
+    redirect_to root_path
   end
 
   private

--- a/app/models/area.rb
+++ b/app/models/area.rb
@@ -1,23 +1,23 @@
 class Area < ActiveHash::Base
   self.data = [
-    {id: 0, name: '--'}, {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, 
-    {id: 3, name: '岩手県'}, {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, 
-    {id: 6, name: '山形県'}, {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, 
-    {id: 9, name: '栃木県'}, {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, 
-    {id: 12, name: '千葉県'}, {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, 
-    {id: 15, name: '新潟県'}, {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, 
-    {id: 18, name: '福井県'}, {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, 
-    {id: 21, name: '岐阜県'}, {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, 
-    {id: 24, name: '三重県'}, {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, 
-    {id: 27, name: '大阪府'}, {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, 
-    {id: 30, name: '和歌山県'}, {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, 
-    {id: 33, name: '岡山県'}, {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, 
-    {id: 36, name: '徳島県'}, {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, 
-    {id: 39, name: '高知県'}, {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, 
-    {id: 42, name: '長崎県'}, {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, 
-    {id: 45, name: '宮崎県'}, {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+    { id: 0, name: '--' }, { id: 1, name: '北海道' }, { id: 2, name: '青森県' },
+    { id: 3, name: '岩手県' }, { id: 4, name: '宮城県' }, { id: 5, name: '秋田県' },
+    { id: 6, name: '山形県' }, { id: 7, name: '福島県' }, { id: 8, name: '茨城県' },
+    { id: 9, name: '栃木県' }, { id: 10, name: '群馬県' }, { id: 11, name: '埼玉県' },
+    { id: 12, name: '千葉県' }, { id: 13, name: '東京都' }, { id: 14, name: '神奈川県' },
+    { id: 15, name: '新潟県' }, { id: 16, name: '富山県' }, { id: 17, name: '石川県' },
+    { id: 18, name: '福井県' }, { id: 19, name: '山梨県' }, { id: 20, name: '長野県' },
+    { id: 21, name: '岐阜県' }, { id: 22, name: '静岡県' }, { id: 23, name: '愛知県' },
+    { id: 24, name: '三重県' }, { id: 25, name: '滋賀県' }, { id: 26, name: '京都府' },
+    { id: 27, name: '大阪府' }, { id: 28, name: '兵庫県' }, { id: 29, name: '奈良県' },
+    { id: 30, name: '和歌山県' }, { id: 31, name: '鳥取県' }, { id: 32, name: '島根県' },
+    { id: 33, name: '岡山県' }, { id: 34, name: '広島県' }, { id: 35, name: '山口県' },
+    { id: 36, name: '徳島県' }, { id: 37, name: '香川県' }, { id: 38, name: '愛媛県' },
+    { id: 39, name: '高知県' }, { id: 40, name: '福岡県' }, { id: 41, name: '佐賀県' },
+    { id: 42, name: '長崎県' }, { id: 43, name: '熊本県' }, { id: 44, name: '大分県' },
+    { id: 45, name: '宮崎県' }, { id: 46, name: '鹿児島県' }, { id: 47, name: '沖縄県' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :items
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,16 +1,16 @@
 class Category < ActiveHash::Base
   self.data = [
-    { id: 0  , name: " -- " },
-    { id: 1  , name: " レディース " },
-    { id: 2  , name: " メンズ " },
-    { id: 3  , name: " ベビー・キッズ" },
-    { id: 4  , name: " インテリア・住まい・小物 " },
-    { id: 5  , name: " 本・音楽・ゲーム " },
-    { id: 6  , name: " おもちゃ・ホビー・グッズ " },
-    { id: 7  , name: " 家電・スマホ・カメラ " },
-    { id: 8  , name: " スポーツ・レジャー " },
-    { id: 9  , name: " ハンドメイド " },
-    { id: 10 , name: " その他 " },
+    { id: 0, name: ' -- ' },
+    { id: 1, name: ' レディース ' },
+    { id: 2, name: ' メンズ ' },
+    { id: 3, name: ' ベビー・キッズ' },
+    { id: 4, name: ' インテリア・住まい・小物 ' },
+    { id: 5, name: ' 本・音楽・ゲーム ' },
+    { id: 6, name: ' おもちゃ・ホビー・グッズ ' },
+    { id: 7, name: ' 家電・スマホ・カメラ ' },
+    { id: 8, name: ' スポーツ・レジャー ' },
+    { id: 9, name: ' ハンドメイド ' },
+    { id: 10, name: ' その他 ' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,9 +6,11 @@ class Item < ApplicationRecord
               :shipping_id,
               :area_id,
               :schedule_id,
-                numericality:{ other_than: 0 }
+              numericality: { other_than: 0 }
     validates :image
-    validates :price, numericality:{ greater_than_or_equal_to: 300, less_than: 10000000, message: "is invalid. Input half-width characters. 300 ~ 9,999,999" }
+    validates :price,
+              numericality: { greater_than_or_equal_to: 300, less_than: 10_000_000,
+                              message: 'is invalid. Input half-width characters. 300 ~ 9,999,999' }
   end
 
   # ActiveHashのアソシエーション

--- a/app/models/item_status.rb
+++ b/app/models/item_status.rb
@@ -1,12 +1,12 @@
 class ItemStatus < ActiveHash::Base
   self.data = [
-    { id: 0  , name: " -- " },
-    { id: 1  , name: " 新品、未使用 " },
-    { id: 2  , name: " 未使用に近い " },
-    { id: 3  , name: " 目立った傷や汚れなし" },
-    { id: 4  , name: " やや傷や汚れあり " },
-    { id: 5  , name: " 傷や汚れあり " },
-    { id: 6  , name: " 全体的に状態が悪い " },
+    { id: 0, name: ' -- ' },
+    { id: 1, name: ' 新品、未使用 ' },
+    { id: 2, name: ' 未使用に近い ' },
+    { id: 3, name: ' 目立った傷や汚れなし' },
+    { id: 4, name: ' やや傷や汚れあり ' },
+    { id: 5, name: ' 傷や汚れあり ' },
+    { id: 6, name: ' 全体的に状態が悪い ' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -1,9 +1,9 @@
 class Schedule < ActiveHash::Base
   self.data = [
-    { id: 0  , name: " -- " },
-    { id: 1  , name: " １〜２日で発送 " },
-    { id: 2  , name: " ２〜３日で発送 " },
-    { id: 3  , name: " ４〜７日で発送 " },
+    { id: 0, name: ' -- ' },
+    { id: 1, name: ' １〜２日で発送 ' },
+    { id: 2, name: ' ２〜３日で発送 ' },
+    { id: 3, name: ' ４〜７日で発送 ' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/shipping.rb
+++ b/app/models/shipping.rb
@@ -1,8 +1,8 @@
 class Shipping < ActiveHash::Base
   self.data = [
-    { id: 0  , name: " -- " },
-    { id: 1  , name: " 着払い（購入者負担） " },
-    { id: 2  , name: " 送料込み（出品者負担） " },
+    { id: 0, name: ' -- ' },
+    { id: 1, name: ' 着払い（購入者負担） ' },
+    { id: 2, name: ' 送料込み（出品者負担） ' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,17 +7,18 @@ class User < ApplicationRecord
   with_options presence: true do # 複数のバリデーションを同時に設定する
     validates :nickname
     # 全角ひらがな、カタカナ、漢字のみ許可する
-    validates :last_name, format: {with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: "is invalid. Input full-width characters."}
-    validates :first_name, format: {with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: "is invalid. Input full-width characters."}
+    validates :last_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters.' }
+    validates :first_name, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/, message: 'is invalid. Input full-width characters.' }
     # カタカナのみ許可する
-    validates :last_reading, format: {with: /\A[ァ-ヶー]+\z/, message: "is invalid. Input full-width katakana characters."}
-    validates :first_reading, format: {with: /\A[ァ-ヶー]+\z/, message: "is invalid. Input full-width katakana characters."}
+    validates :last_reading, format: { with: /\A[ァ-ヶー]+\z/, message: 'is invalid. Input full-width katakana characters.' }
+    validates :first_reading, format: { with: /\A[ァ-ヶー]+\z/, message: 'is invalid. Input full-width katakana characters.' }
     # format:は、with（正規表現）と属性値がマッチするか
     # マッチしなければ、messageに指定されたエラーメッセージを返す
     validates :birthday
   end
-    # passwordの英数字混合正規表現
-    validates :password, format: {with: (/\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i), message: "is invalid. Input alphabet & numeral characters. "}
-  
+  # passwordの英数字混合正規表現
+  validates :password,
+            format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'is invalid. Input alphabet & numeral characters. ' }
+
   has_many :items
 end

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
       <% if @item.user.id == current_user.id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %> <%# 売れていない場合の処理は、購入機能実装後条件を追加する %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
 
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
+  resources :items
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :item do
-    name {Faker::Lorem.word}
-    info {Faker::Lorem.word}
-    category_id {Faker::Number.within(range: 1..2)}
-    item_status_id {Faker::Number.within(range: 1..2)}
-    shipping_id {Faker::Number.within(range: 1..2)}
-    area_id {Faker::Number.within(range: 1..2)}
-    schedule_id {Faker::Number.within(range: 3..6)}
-    price {Faker::Number.number(digits: 4)}
+    name { Faker::Lorem.word }
+    info { Faker::Lorem.word }
+    category_id { Faker::Number.within(range: 1..2) }
+    item_status_id { Faker::Number.within(range: 1..2) }
+    shipping_id { Faker::Number.within(range: 1..2) }
+    area_id { Faker::Number.within(range: 1..2) }
+    schedule_id { Faker::Number.within(range: 3..6) }
+    price { Faker::Number.number(digits: 4) }
 
     association :user
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :user do
-    email                 {Faker::Internet.free_email}
+    email                 { Faker::Internet.free_email }
     # password英数字混合を実現するため 1a を追加する
-    password              {'1a'+Faker::Internet.password(min_length: 6)}
-    password_confirmation {password}
-    nickname              {Gimei.name}
-    last_name             {Gimei.name.last}
-    first_name            {Gimei.name.first}
-    last_reading          {Gimei.name.katakana.last}
-    first_reading         {Gimei.name.katakana.first}
-    birthday              {Faker::Date.birthday(max_age:65)}
+    password              { '1a' + Faker::Internet.password(min_length: 6) }
+    password_confirmation { password }
+    nickname              { Gimei.name }
+    last_name             { Gimei.name.last }
+    first_name            { Gimei.name.first }
+    last_reading          { Gimei.name.katakana.last }
+    first_reading         { Gimei.name.katakana.first }
+    birthday              { Faker::Date.birthday(max_age: 65) }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -17,99 +17,99 @@ RSpec.describe Item, type: :model do
         expect(@item.errors.full_messages).to include "Image can't be blank"
       end
       it '商品名が空では保存ができない' do
-        @item.name = ""
+        @item.name = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Name can't be blank"
       end
       it '商品の説明が空では保存ができない' do
-        @item.info = ""
+        @item.info = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Info can't be blank"
       end
       it 'カテゴリーが空では保存ができない' do
-        @item.category_id = ""
+        @item.category_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Category can't be blank"
       end
       it 'カテゴリーが「0」では保存ができない' do
         @item.category_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Category must be other than 0"
+        expect(@item.errors.full_messages).to include 'Category must be other than 0'
       end
       it '商品の状態が空では保存ができない' do
-        @item.item_status_id = ""
+        @item.item_status_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Item status can't be blank"
       end
       it '商品の状態が「0」では保存ができない' do
         @item.item_status_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Item status must be other than 0"
+        expect(@item.errors.full_messages).to include 'Item status must be other than 0'
       end
       it '配送料の負担が空では保存ができない' do
-        @item.shipping_id = ""
+        @item.shipping_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Shipping can't be blank"
       end
       it '配送料の負担が「0」では保存ができない' do
         @item.shipping_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Shipping must be other than 0"
+        expect(@item.errors.full_messages).to include 'Shipping must be other than 0'
       end
       it '発送元の地域が空では保存ができない' do
-        @item.area_id = ""
+        @item.area_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Area can't be blank"
       end
       it '発送元の地域が「0」では保存ができない' do
         @item.area_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Area must be other than 0"
+        expect(@item.errors.full_messages).to include 'Area must be other than 0'
       end
       it '発送までの日数が空では保存ができない' do
-        @item.schedule_id = ""
+        @item.schedule_id = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Schedule can't be blank"
       end
       it '発送までの日数が「0」では保存ができない' do
         @item.schedule_id = 0
         @item.valid?
-        expect(@item.errors.full_messages).to include "Schedule must be other than 0"
+        expect(@item.errors.full_messages).to include 'Schedule must be other than 0'
       end
       it '価格が空では保存ができない' do
-        @item.price = ""
+        @item.price = ''
         @item.valid?
         expect(@item.errors.full_messages).to include "Price can't be blank"
       end
       it '価格が299以下では保存ができない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is invalid. Input half-width characters. 300 ~ 9,999,999"
+        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters. 300 ~ 9,999,999'
       end
       it '価格が10000000では保存ができない' do
-        @item.price = 10000000
+        @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is invalid. Input half-width characters. 300 ~ 9,999,999"
+        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters. 300 ~ 9,999,999'
       end
       it '価格が全角文字では保存ができない' do
-        @item.price = "全角文字"
+        @item.price = '全角文字'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is invalid. Input half-width characters. 300 ~ 9,999,999"
+        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters. 300 ~ 9,999,999'
       end
       it '価格が半角英字では保存ができない' do
-        @item.price = "hankaku"
+        @item.price = 'hankaku'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is invalid. Input half-width characters. 300 ~ 9,999,999"
+        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters. 300 ~ 9,999,999'
       end
       it '価格が半角英数字混合では保存ができない' do
-        @item.price = "kongou1"
+        @item.price = 'kongou1'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is invalid. Input half-width characters. 300 ~ 9,999,999"
+        expect(@item.errors.full_messages).to include 'Price is invalid. Input half-width characters. 300 ~ 9,999,999'
       end
       it 'userが紐付いていないと保存できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "User must exist"
+        expect(@item.errors.full_messages).to include 'User must exist'
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,111 +15,111 @@ RSpec.describe User, type: :model do
 
     context '異常系テスト' do
       it 'emailが空では登録ができない' do
-        @user.email  = ""
+        @user.email = ''
         @user.valid?
         expect(@user.errors.full_messages).to include "Email can't be blank"
       end
       it 'emailが重複すると登録できない' do
-        @user.save 
+        @user.save
         another_user = FactoryBot.build(:user, email: @user.email)
         another_user.valid?
         expect(another_user.errors.full_messages).to include('Email has already been taken')
       end
       it 'passwordが空では登録ができない' do
-        @user.password  = ""
+        @user.password = ''
         @user.valid?
         expect(@user.errors.full_messages).to include "Password can't be blank"
       end
       it 'passwordが英語のみでは登録ができない' do
-        @user.password  = "abcdefg"
+        @user.password = 'abcdefg'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid. Input alphabet & numeral characters. "
+        expect(@user.errors.full_messages).to include 'Password is invalid. Input alphabet & numeral characters. '
       end
       it 'passwordが数字のみでは登録ができない' do
-        @user.password  = "1234567"
+        @user.password = '1234567'
         @user.password_confirmation = @user.password
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid. Input alphabet & numeral characters. "
+        expect(@user.errors.full_messages).to include 'Password is invalid. Input alphabet & numeral characters. '
       end
       it 'passwordが5文字以下であれば登録できない' do
-        @user.password = "12345"
-        @user.password_confirmation = "12345"
+        @user.password = '12345'
+        @user.password_confirmation = '12345'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is too short (minimum is 6 characters)"
+        expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
       end
       it 'passwordとpassword_confirmationが不一致では登録できない' do
-        @user.password_confirmation = "123456"
+        @user.password_confirmation = '123456'
         @user.valid?
         expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
       end
       it 'nicknameが空では登録ができない' do
-        @user.nickname  = ""
+        @user.nickname = ''
         @user.valid?
         expect(@user.errors.full_messages).to include "Nickname can't be blank"
       end
       it 'last_nameが空では登録ができない' do
-        @user.last_name  = ""
+        @user.last_name = ''
         @user.valid?
         expect(@user.errors.full_messages).to include "Last name can't be blank"
       end
       it 'last_nameが半角文字では登録ができない' do
-        @user.last_name  = "hankaku"
+        @user.last_name = 'hankaku'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name is invalid. Input full-width characters."
+        expect(@user.errors.full_messages).to include 'Last name is invalid. Input full-width characters.'
       end
       it 'first_nameが空では登録ができない' do
-        @user.first_name  = ""
+        @user.first_name = ''
         @user.valid?
         expect(@user.errors.full_messages).to include "First name can't be blank"
       end
       it 'first_nameが半角文字では登録ができない' do
-        @user.first_name  = "hankaku"
+        @user.first_name = 'hankaku'
         @user.valid?
-        expect(@user.errors.full_messages).to include "First name is invalid. Input full-width characters."
+        expect(@user.errors.full_messages).to include 'First name is invalid. Input full-width characters.'
       end
       it 'last_readingが空では登録ができない' do
-        @user.last_reading  = ""
+        @user.last_reading = ''
         @user.valid?
         expect(@user.errors.full_messages).to include "Last reading can't be blank"
       end
       it 'last_readingが半角文字では登録ができない' do
-        @user.last_reading  = "hankaku"
+        @user.last_reading = 'hankaku'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last reading is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'Last reading is invalid. Input full-width katakana characters.'
       end
       it 'last_readingがひらがなでは登録ができない' do
-        @user.last_reading  = "ひらがな"
+        @user.last_reading = 'ひらがな'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last reading is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'Last reading is invalid. Input full-width katakana characters.'
       end
       it 'last_readingが漢字では登録ができない' do
-        @user.last_reading  = "漢字"
+        @user.last_reading = '漢字'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last reading is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'Last reading is invalid. Input full-width katakana characters.'
       end
       it 'first_readingが空では登録ができない' do
-        @user.first_reading  = ""
+        @user.first_reading = ''
         @user.valid?
         expect(@user.errors.full_messages).to include "First reading can't be blank"
       end
       it 'first_readingが半角文字では登録ができない' do
-        @user.first_reading  = "hankaku"
+        @user.first_reading = 'hankaku'
         @user.valid?
-        expect(@user.errors.full_messages).to include "First reading is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'First reading is invalid. Input full-width katakana characters.'
       end
       it 'first_readingがひらがなでは登録ができない' do
-        @user.first_reading  = "ひらがな"
+        @user.first_reading = 'ひらがな'
         @user.valid?
-        expect(@user.errors.full_messages).to include "First reading is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'First reading is invalid. Input full-width katakana characters.'
       end
       it 'first_readingが漢字では登録ができない' do
-        @user.first_reading  = "漢字"
+        @user.first_reading = '漢字'
         @user.valid?
-        expect(@user.errors.full_messages).to include "First reading is invalid. Input full-width katakana characters."
+        expect(@user.errors.full_messages).to include 'First reading is invalid. Input full-width katakana characters.'
       end
       it 'birthdayが空では登録ができない' do
-        @user.birthday  = ""
+        @user.birthday = ''
         @user.valid?
         expect(@user.errors.full_messages).to include "Birthday can't be blank"
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,53 +44,51 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
-  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
-  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do


### PR DESCRIPTION
# What(何を実装したか)
・ルーティング設定
・コントローラー　
→destroyアクション定義、ルートへリダイレクトされる
・ビュー
→削除ボタンの設置

# Why(なぜ実装したのか)
商品削除機能の実装のため

# Gyazo
- ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/0a32e58651131694f1dac19c1ecb44dd